### PR TITLE
working child workflows

### DIFF
--- a/infinitic-avro/src/main/avro/io/infinitic/workflowManager/data/methodRuns/AvroMethodRun.avsc
+++ b/infinitic-avro/src/main/avro/io/infinitic/workflowManager/data/methodRuns/AvroMethodRun.avsc
@@ -14,7 +14,25 @@
     },
     {
       "name": "parentWorkflowId",
-      "type": "string"
+      "type": [
+        "null",
+        {
+          "type": "string",
+          "logicalType": "uuid"
+        }
+      ],
+      "default": null
+    },
+    {
+      "name": "parentMethodRunId",
+      "type": [
+        "null",
+        {
+          "type": "string",
+          "logicalType": "uuid"
+        }
+      ],
+      "default": null
     },
     {
       "name": "methodName",

--- a/infinitic-avro/src/main/avro/io/infinitic/workflowManager/data/states/AvroWorkflowState.avsc
+++ b/infinitic-avro/src/main/avro/io/infinitic/workflowManager/data/states/AvroWorkflowState.avsc
@@ -28,6 +28,13 @@
       "type": "io.infinitic.workflowManager.data.workflows.AvroWorkflowOptions"
     },
     {
+      "name": "workflowMeta",
+      "type": {
+        "type": "map",
+        "values": "io.infinitic.taskManager.data.AvroSerializedData"
+      }
+    },
+    {
       "name": "currentWorkflowTaskId",
       "type": [
         "null",

--- a/infinitic-avro/src/main/avro/io/infinitic/workflowManager/messages/AvroChildWorkflowCompleted.avsc
+++ b/infinitic-avro/src/main/avro/io/infinitic/workflowManager/messages/AvroChildWorkflowCompleted.avsc
@@ -9,6 +9,11 @@
       "logicalType": "uuid"
     },
     {
+      "name": "methodRunId",
+      "type": "string",
+      "logicalType": "uuid"
+    },
+    {
       "name": "childWorkflowId",
       "type": "string",
       "logicalType": "uuid"

--- a/infinitic-taskManager-worker/src/main/kotlin/io/infinitic/taskManager/worker/Worker.kt
+++ b/infinitic-taskManager-worker/src/main/kotlin/io/infinitic/taskManager/worker/Worker.kt
@@ -154,7 +154,7 @@ open class Worker(val dispatcher: Dispatcher) {
         }
     }
 
-    fun getTaskInstance(name: String): Any {
+    fun getInstance(name: String): Any {
         // return registered instance if any
         if (registeredTasks.containsKey(name)) return registeredTasks[name]!!
 
@@ -188,7 +188,7 @@ open class Worker(val dispatcher: Dispatcher) {
 
     private fun parse(msg: RunTask): TaskCommand {
         val (taskName, methodName) = getClassAndMethodName("${msg.taskName}")
-        val task = getTaskInstance(taskName)
+        val task = getInstance(taskName)
         val parameterTypes = msg.taskMeta.parameterTypes
         val method = if (parameterTypes == null) {
             getMethodPerNameAndParameterCount(task, methodName, msg.taskInput.size)

--- a/infinitic-workflowManager-common/src/main/kotlin/io/infinitic/workflowManager/common/avro/AvroConverter.kt
+++ b/infinitic-workflowManager-common/src/main/kotlin/io/infinitic/workflowManager/common/avro/AvroConverter.kt
@@ -54,6 +54,7 @@ object AvroConverter {
         parentWorkflowId = avro.parentWorkflowId?.let { WorkflowId(it) },
         workflowName = WorkflowName(avro.workflowName),
         workflowOptions = convertJson(avro.workflowOptions),
+        workflowMeta = convertJson(avro.workflowMeta),
         currentWorkflowTaskId = avro.currentWorkflowTaskId?.let { WorkflowTaskId(it) },
         currentMessageIndex = WorkflowMessageIndex(avro.currentMessageIndex),
         currentMethodRuns = avro.currentMethodRuns.map { convertJson<MethodRun>(it) }.toMutableList(),
@@ -68,6 +69,7 @@ object AvroConverter {
         .setParentWorkflowId(state.parentWorkflowId?.toString())
         .setWorkflowName("${state.workflowName}")
         .setWorkflowOptions(convertJson(state.workflowOptions))
+        .setWorkflowMeta(convertJson(state.workflowMeta))
         .setCurrentWorkflowTaskId("${state.currentWorkflowTaskId}")
         .setCurrentMessageIndex(convertJson(state.currentMessageIndex))
         .setCurrentMethodRuns(state.currentMethodRuns.map { convertJson<AvroMethodRun>(it) })

--- a/infinitic-workflowManager-common/src/main/kotlin/io/infinitic/workflowManager/common/data/commands/Command.kt
+++ b/infinitic-workflowManager-common/src/main/kotlin/io/infinitic/workflowManager/common/data/commands/Command.kt
@@ -11,6 +11,7 @@ import io.infinitic.taskManager.common.data.TaskName
 import io.infinitic.workflowManager.common.data.methodRuns.MethodName
 import io.infinitic.workflowManager.common.data.methodRuns.MethodInput
 import io.infinitic.workflowManager.common.data.workflows.WorkflowName
+import java.lang.reflect.Method
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 @JsonSubTypes(
@@ -39,7 +40,15 @@ data class DispatchTask(
     val taskInput: TaskInput,
     @JsonProperty("meta")
     val taskMeta: TaskMeta
-) : Command()
+) : Command() {
+    companion object {
+        fun from(method: Method, args: Array<out Any>) = DispatchTask(
+            taskName = TaskName.from(method),
+            taskInput = TaskInput.from(method, args),
+            taskMeta = TaskMeta().withParametersTypesFrom(method)
+        )
+    }
+}
 
 data class DispatchChildWorkflow(
     @JsonProperty("name")
@@ -48,7 +57,15 @@ data class DispatchChildWorkflow(
     val childMethodName: MethodName,
     @JsonProperty("input")
     val childMethodInput: MethodInput
-) : Command()
+) : Command() {
+    companion object {
+        fun from(method: Method, args: Array<out Any>) = DispatchChildWorkflow(
+            childWorkflowName = WorkflowName.from(method),
+            childMethodName = MethodName.from(method),
+            childMethodInput = MethodInput.from(method, args)
+        )
+    }
+}
 
 object StartAsync : Command() {
     // as we can not define a data class without parameter, we add manually the equals func

--- a/infinitic-workflowManager-common/src/main/kotlin/io/infinitic/workflowManager/common/data/methodRuns/MethodRun.kt
+++ b/infinitic-workflowManager-common/src/main/kotlin/io/infinitic/workflowManager/common/data/methodRuns/MethodRun.kt
@@ -10,6 +10,7 @@ data class MethodRun(
     val methodRunId: MethodRunId = MethodRunId(),
     val isMain: Boolean,
     val parentWorkflowId: WorkflowId? = null,
+    val parentMethodRunId: MethodRunId? = null,
     val methodName: MethodName,
     val methodInput: MethodInput,
     var methodOutput: MethodOutput? = null,

--- a/infinitic-workflowManager-common/src/main/kotlin/io/infinitic/workflowManager/common/data/states/States.kt
+++ b/infinitic-workflowManager-common/src/main/kotlin/io/infinitic/workflowManager/common/data/states/States.kt
@@ -6,6 +6,7 @@ import io.infinitic.workflowManager.common.data.methodRuns.MethodRun
 import io.infinitic.workflowManager.common.data.properties.Properties
 import io.infinitic.workflowManager.common.data.properties.PropertyStore
 import io.infinitic.workflowManager.common.data.workflows.WorkflowMessageIndex
+import io.infinitic.workflowManager.common.data.workflows.WorkflowMeta
 import io.infinitic.workflowManager.common.data.workflows.WorkflowName
 import io.infinitic.workflowManager.common.data.workflows.WorkflowOptions
 import io.infinitic.workflowManager.common.messages.ForWorkflowEngineMessage
@@ -17,6 +18,7 @@ data class WorkflowState(
     val parentWorkflowId: WorkflowId? = null,
     val workflowName: WorkflowName,
     val workflowOptions: WorkflowOptions,
+    val workflowMeta: WorkflowMeta,
     var currentWorkflowTaskId: WorkflowTaskId? = null,
     var currentMessageIndex: WorkflowMessageIndex = WorkflowMessageIndex(0),
     val currentMethodRuns: MutableList<MethodRun>,

--- a/infinitic-workflowManager-common/src/main/kotlin/io/infinitic/workflowManager/common/data/workflows/WorkflowName.kt
+++ b/infinitic-workflowManager-common/src/main/kotlin/io/infinitic/workflowManager/common/data/workflows/WorkflowName.kt
@@ -3,7 +3,12 @@ package io.infinitic.workflowManager.common.data.workflows
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonValue
 import io.infinitic.taskManager.common.data.bases.Name
+import java.lang.reflect.Method
 
 data class WorkflowName
 @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
-constructor(@get:JsonValue override val name: String) : Name(name)
+constructor(@get:JsonValue override val name: String) : Name(name) {
+    companion object {
+        fun from(method: Method) = WorkflowName(method.declaringClass.name)
+    }
+}

--- a/infinitic-workflowManager-common/src/main/kotlin/io/infinitic/workflowManager/common/messages/Message.kt
+++ b/infinitic-workflowManager-common/src/main/kotlin/io/infinitic/workflowManager/common/messages/Message.kt
@@ -35,6 +35,7 @@ data class ChildWorkflowCanceled(
 
 data class ChildWorkflowCompleted(
     override val workflowId: WorkflowId,
+    val methodRunId: MethodRunId,
     val childWorkflowId: WorkflowId,
     val childWorkflowOutput: MethodOutput
 ) : ForWorkflowEngineMessage(workflowId)

--- a/infinitic-workflowManager-engine/src/main/kotlin/io/infinitic/workflowManager/engine/engines/WorkflowEngine.kt
+++ b/infinitic-workflowManager-engine/src/main/kotlin/io/infinitic/workflowManager/engine/engines/WorkflowEngine.kt
@@ -18,6 +18,7 @@ import io.infinitic.workflowManager.common.messages.TaskCompleted
 import io.infinitic.workflowManager.common.messages.TaskDispatched
 import io.infinitic.workflowManager.common.messages.WorkflowCanceled
 import io.infinitic.workflowManager.common.messages.WorkflowCompleted
+import io.infinitic.workflowManager.engine.engines.handlers.ChildWorkflowCompletedHandler
 import io.infinitic.workflowManager.engine.engines.handlers.DispatchWorkflowHandler
 import io.infinitic.workflowManager.engine.engines.handlers.TaskCompletedHandler
 import io.infinitic.workflowManager.engine.engines.handlers.WorkflowTaskCompletedHandler
@@ -127,9 +128,8 @@ class WorkflowEngine(
         TODO()
     }
 
-    private suspend fun childWorkflowCompleted(state: WorkflowState, msg: ChildWorkflowCompleted): WorkflowState {
-        TODO()
-    }
+    private suspend fun childWorkflowCompleted(state: WorkflowState, msg: ChildWorkflowCompleted) =
+        ChildWorkflowCompletedHandler(dispatcher).handle(state, msg)
 
     private suspend fun objectReceived(state: WorkflowState, msg: ObjectReceived): WorkflowState {
         TODO()

--- a/infinitic-workflowManager-engine/src/main/kotlin/io/infinitic/workflowManager/engine/engines/handlers/ChildWorkflowCompletedHandler.kt
+++ b/infinitic-workflowManager-engine/src/main/kotlin/io/infinitic/workflowManager/engine/engines/handlers/ChildWorkflowCompletedHandler.kt
@@ -5,17 +5,17 @@ import io.infinitic.workflowManager.common.data.commands.CommandId
 import io.infinitic.workflowManager.common.data.commands.CommandOutput
 import io.infinitic.workflowManager.common.data.commands.CommandStatusCompleted
 import io.infinitic.workflowManager.common.data.commands.CommandStatusOngoing
-import io.infinitic.workflowManager.common.messages.TaskCompleted
 import io.infinitic.workflowManager.common.data.states.WorkflowState
+import io.infinitic.workflowManager.common.messages.ChildWorkflowCompleted
 
-class TaskCompletedHandler(
+class ChildWorkflowCompletedHandler(
     override val dispatcher: Dispatcher
 ) : MsgHandler(dispatcher) {
-    suspend fun handle(state: WorkflowState, msg: TaskCompleted) {
+    suspend fun handle(state: WorkflowState, msg: ChildWorkflowCompleted) {
         val methodRun = getMethodRun(state, msg.methodRunId)
 
         // update command status
-        val commandId = CommandId(msg.taskId)
+        val commandId = CommandId(msg.childWorkflowId)
         val pastCommand = methodRun.pastCommands.first { it.commandId == commandId }
 
         // do nothing if this command is not ongoing (could have been canceled)
@@ -23,7 +23,7 @@ class TaskCompletedHandler(
 
         // update command status
         pastCommand.commandStatus = CommandStatusCompleted(
-            CommandOutput(msg.taskOutput.data),
+            CommandOutput(msg.childWorkflowOutput.data),
             state.currentMessageIndex
         )
 

--- a/infinitic-workflowManager-engine/src/main/kotlin/io/infinitic/workflowManager/engine/engines/handlers/DispatchWorkflowHandler.kt
+++ b/infinitic-workflowManager-engine/src/main/kotlin/io/infinitic/workflowManager/engine/engines/handlers/DispatchWorkflowHandler.kt
@@ -26,6 +26,7 @@ class DispatchWorkflowHandler(
         val methodRun = MethodRun(
             isMain = true,
             parentWorkflowId = msg.parentWorkflowId,
+            parentMethodRunId = msg.parentMethodRunId,
             methodName = msg.methodName,
             methodInput = msg.methodInput,
             messageIndexAtStart = WorkflowMessageIndex(0)
@@ -72,6 +73,7 @@ class DispatchWorkflowHandler(
             workflowId = msg.workflowId,
             workflowName = msg.workflowName,
             workflowOptions = msg.workflowOptions,
+            workflowMeta = msg.workflowMeta,
             currentWorkflowTaskId = workflowTaskId,
             currentMethodRuns = mutableListOf(methodRun)
         )

--- a/infinitic-workflowManager-engine/src/main/kotlin/io/infinitic/workflowManager/engine/engines/handlers/MsgHandler.kt
+++ b/infinitic-workflowManager-engine/src/main/kotlin/io/infinitic/workflowManager/engine/engines/handlers/MsgHandler.kt
@@ -61,4 +61,15 @@ abstract class MsgHandler(
 
         state.currentWorkflowTaskId = workflowTaskId
     }
+
+    protected fun cleanMethodRun(methodRun: MethodRun, state: WorkflowState) {
+        // if everything is completed in methodRun then filter state
+        if (methodRun.methodOutput != null &&
+            methodRun.pastCommands.all { it.isTerminated() } &&
+            methodRun.pastSteps.all { it.isTerminated() }
+        ) {
+            // TODO("filter workflow if unused properties")
+            state.currentMethodRuns.remove(methodRun)
+        }
+    }
 }

--- a/infinitic-workflowManager-tests/src/test/kotlin/io/infinitic/workflowManager/tests/WorkflowIntegrationTests.kt
+++ b/infinitic-workflowManager-tests/src/test/kotlin/io/infinitic/workflowManager/tests/WorkflowIntegrationTests.kt
@@ -230,4 +230,16 @@ class WorkflowIntegrationTests : StringSpec({
         // checks number of task processing
         dispatcher.workflowOutput shouldBe "21abc21"
     }
+
+    "Nested Child Workflow" {
+        // run system
+        coroutineScope {
+            dispatcher.scope = this
+            workflowInstance = client.dispatchWorkflow<WorkflowB> { factorial(14) }
+        }
+        // check that the w is terminated
+        storage.isTerminated(workflowInstance) shouldBe true
+        // checks number of task processing
+        dispatcher.workflowOutput shouldBe 87178291200
+    }
 })

--- a/infinitic-workflowManager-tests/src/test/kotlin/io/infinitic/workflowManager/tests/samples/WorkflowA.kt
+++ b/infinitic-workflowManager-tests/src/test/kotlin/io/infinitic/workflowManager/tests/samples/WorkflowA.kt
@@ -21,10 +21,13 @@ interface WorkflowA {
     fun inline(): String
     fun inline2(): String
     fun inline3(): String
+    fun child1(): String
+    fun child2(): String
 }
 
 class WorkflowAImpl : Workflow(), WorkflowA {
     private val task = proxy<TaskA>()
+    private val workflowB = proxy<WorkflowB>()
 
     override fun empty() = "void"
 
@@ -143,5 +146,20 @@ class WorkflowAImpl : Workflow(), WorkflowA {
             LocalDateTime.now()
         }
         return task.concat("Current Date and Time is: ", "$date") // should throw
+    }
+
+    override fun child1(): String {
+
+        var str: String = workflowB.concat("-")
+        str = task.concat(str, "-")
+
+        return str // should be "-abc-"
+    }
+
+    override fun child2(): String {
+        val str = task.reverse("12")
+        val d = async(workflowB) { concat(str) }
+
+        return task.concat(d.result(), str) // should be "21abc21"
     }
 }

--- a/infinitic-workflowManager-tests/src/test/kotlin/io/infinitic/workflowManager/tests/samples/WorkflowB.kt
+++ b/infinitic-workflowManager-tests/src/test/kotlin/io/infinitic/workflowManager/tests/samples/WorkflowB.kt
@@ -1,0 +1,21 @@
+package io.infinitic.workflowManager.tests.samples
+
+import io.infinitic.workflowManager.worker.Workflow
+
+interface WorkflowB {
+    fun concat(input: String): String
+}
+
+class WorkflowBImpl : Workflow(), WorkflowB {
+    private val task = proxy<TaskA>()
+
+    override fun concat(input: String): String {
+        var str = input
+
+        str = task.concat(str, "a")
+        str = task.concat(str, "b")
+        str = task.concat(str, "c")
+
+        return str // should be "${input}123"
+    }
+}

--- a/infinitic-workflowManager-tests/src/test/kotlin/io/infinitic/workflowManager/tests/samples/WorkflowB.kt
+++ b/infinitic-workflowManager-tests/src/test/kotlin/io/infinitic/workflowManager/tests/samples/WorkflowB.kt
@@ -4,10 +4,12 @@ import io.infinitic.workflowManager.worker.Workflow
 
 interface WorkflowB {
     fun concat(input: String): String
+    fun factorial(n: Long): Long
 }
 
 class WorkflowBImpl : Workflow(), WorkflowB {
     private val task = proxy<TaskA>()
+    private val workflow = proxy<WorkflowB>()
 
     override fun concat(input: String): String {
         var str = input
@@ -17,5 +19,13 @@ class WorkflowBImpl : Workflow(), WorkflowB {
         str = task.concat(str, "c")
 
         return str // should be "${input}123"
+    }
+
+    override fun factorial(n: Long): Long {
+        return if (n > 1) {
+            n * workflow.factorial(n - 1)
+        } else {
+            1
+        }
     }
 }

--- a/infinitic-workflowManager-worker/src/main/kotlin/io/infinitic/workflowManager/worker/Workflow.kt
+++ b/infinitic-workflowManager-worker/src/main/kotlin/io/infinitic/workflowManager/worker/Workflow.kt
@@ -4,7 +4,7 @@ import io.infinitic.taskManager.common.proxies.MethodProxyHandler
 import io.infinitic.workflowManager.common.exceptions.NoMethodCallAtAsync
 import io.infinitic.workflowManager.common.exceptions.WorkflowTaskContextNotInitialized
 import io.infinitic.workflowManager.worker.deferred.Deferred
-import io.infinitic.workflowManager.worker.commands.TaskProxyHandler
+import io.infinitic.workflowManager.worker.commands.CommandProxy
 import io.infinitic.workflowManager.worker.data.MethodRunContext
 
 abstract class Workflow {
@@ -12,9 +12,9 @@ abstract class Workflow {
         get() = field ?: throw WorkflowTaskContextNotInitialized(this::class.java.name, MethodRunContext::class.java.name)
 
     /*
-     * Use this method to proxy task or child workflows
+     * Use this method to proxy a task or a child workflow
      */
-    protected inline fun <reified T : Any> proxy() = TaskProxyHandler { methodRunContext!! }.instance<T>()
+    protected inline fun <reified T : Any> proxy() = CommandProxy { methodRunContext!! }.instance<T>()
 
     /*
      * Use this method to dispatch a task

--- a/infinitic-workflowManager-worker/src/main/kotlin/io/infinitic/workflowManager/worker/commands/CommandProxy.kt
+++ b/infinitic-workflowManager-worker/src/main/kotlin/io/infinitic/workflowManager/worker/commands/CommandProxy.kt
@@ -5,7 +5,7 @@ import java.lang.reflect.InvocationHandler
 import java.lang.reflect.Method
 import java.lang.reflect.Proxy
 
-class TaskProxyHandler(private val methodRunContext: () -> MethodRunContext) : InvocationHandler {
+class CommandProxy(private val methodRunContext: () -> MethodRunContext) : InvocationHandler {
 
     /*
      * implements the synchronous processing of a task or child workflow


### PR DESCRIPTION
Working implementation of child workflows  🔥

> Fun fact: in a workflow definition, tasks and child-workflows are indistinguable. Actually, the distinction is done  only in the worker when processing WorkflowTask (through the class provided as an actual implementation of the interface)
