### PR TITLE
Improve gradle build

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,4 +40,10 @@ allprojects {
 
 subprojects {
     version = "1.0.0-SNAPSHOT"
+
+    extra["kotest_version"] = "4.2.+"
+    extra["mockk_version"] = "1.10.+"
+    extra["kotlinx_coroutines_version"] = "1.3.+"
+    extra["pulsar_version"] = "2.6.+"
+    extra["easyrandom_version"] = "4.2.+"
 }

--- a/infinitic-avro/build.gradle.kts
+++ b/infinitic-avro/build.gradle.kts
@@ -38,10 +38,10 @@ dependencies {
     implementation("com.fasterxml.jackson.core:jackson-databind:2.11.+")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.11.+")
 
-    testImplementation("org.jeasy:easy-random-core:4.2.+")
-    testImplementation("io.kotest:kotest-runner-junit5-jvm:4.2.+")
-    testImplementation("io.kotest:kotest-property-jvm:4.2.+")
-    testImplementation("io.mockk:mockk:1.10.+")
+    testImplementation("org.jeasy:easy-random-core:${project.extra["easyrandom_version"]}")
+    testImplementation("io.kotest:kotest-runner-junit5-jvm:${project.extra["kotest_version"]}")
+    testImplementation("io.kotest:kotest-property-jvm:${project.extra["kotest_version"]}")
+    testImplementation("io.mockk:mockk:${project.extra["mockk_version"]}")
 }
 
 java {

--- a/infinitic-avro/build.gradle.kts
+++ b/infinitic-avro/build.gradle.kts
@@ -32,6 +32,7 @@ repositories {
 }
 
 dependencies {
+    implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
     implementation(kotlin("stdlib-jdk8"))
     api("org.apache.avro:avro:1.10.+")
     implementation("com.fasterxml.jackson.core:jackson-databind:2.11.+")

--- a/infinitic-avro/build.gradle.kts
+++ b/infinitic-avro/build.gradle.kts
@@ -35,8 +35,6 @@ dependencies {
     implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
     implementation(kotlin("stdlib-jdk8"))
     api("org.apache.avro:avro:1.10.+")
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.11.+")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.11.+")
 
     testImplementation("org.jeasy:easy-random-core:${project.extra["easyrandom_version"]}")
     testImplementation("io.kotest:kotest-runner-junit5-jvm:${project.extra["kotest_version"]}")

--- a/infinitic-client/build.gradle.kts
+++ b/infinitic-client/build.gradle.kts
@@ -41,11 +41,11 @@ dependencies {
     implementation(project(":infinitic-avro"))
     implementation(project(":infinitic-common"))
 
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.9")
-    testImplementation("org.jeasy:easy-random-core:4.2.+")
-    testImplementation("io.kotest:kotest-runner-junit5-jvm:4.2.+")
-    testImplementation("io.kotest:kotest-property-jvm:4.2.+")
-    testImplementation("io.mockk:mockk:1.10.+")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${project.extra["kotlinx_coroutines_version"]}")
+    testImplementation("org.jeasy:easy-random-core:${project.extra["easyrandom_version"]}")
+    testImplementation("io.kotest:kotest-runner-junit5-jvm:${project.extra["kotest_version"]}")
+    testImplementation("io.kotest:kotest-property-jvm:${project.extra["kotest_version"]}")
+    testImplementation("io.mockk:mockk:${project.extra["mockk_version"]}")
 }
 
 java {

--- a/infinitic-client/build.gradle.kts
+++ b/infinitic-client/build.gradle.kts
@@ -32,9 +32,6 @@ plugins {
 dependencies {
     implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
     implementation(kotlin("stdlib-jdk8"))
-    implementation("org.apache.avro:avro:1.10.+")
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.11.+")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.11.+")
     implementation("org.slf4j:slf4j-api:1.7.+")
 
     api(project(":infinitic-messaging-api"))

--- a/infinitic-client/build.gradle.kts
+++ b/infinitic-client/build.gradle.kts
@@ -30,6 +30,7 @@ plugins {
 }
 
 dependencies {
+    implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
     implementation(kotlin("stdlib-jdk8"))
     implementation("org.apache.avro:avro:1.10.+")
     implementation("com.fasterxml.jackson.core:jackson-databind:2.11.+")
@@ -41,7 +42,6 @@ dependencies {
     implementation(project(":infinitic-common"))
 
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.9")
-    testImplementation("org.jetbrains.kotlin:kotlin-reflect:1.4.10")
     testImplementation("org.jeasy:easy-random-core:4.2.+")
     testImplementation("io.kotest:kotest-runner-junit5-jvm:4.2.+")
     testImplementation("io.kotest:kotest-property-jvm:4.2.+")

--- a/infinitic-common/build.gradle.kts
+++ b/infinitic-common/build.gradle.kts
@@ -29,7 +29,6 @@ plugins {
 dependencies {
     implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
     implementation(kotlin("stdlib-jdk8"))
-    implementation("org.apache.avro:avro:1.10.+")
     implementation("com.fasterxml.jackson.core:jackson-databind:2.11.+")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.11.+")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.11.+")

--- a/infinitic-common/build.gradle.kts
+++ b/infinitic-common/build.gradle.kts
@@ -27,6 +27,7 @@ plugins {
 }
 
 dependencies {
+    implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
     implementation(kotlin("stdlib-jdk8"))
     implementation("org.apache.avro:avro:1.10.+")
     implementation("com.fasterxml.jackson.core:jackson-databind:2.11.+")

--- a/infinitic-common/build.gradle.kts
+++ b/infinitic-common/build.gradle.kts
@@ -36,10 +36,10 @@ dependencies {
 
     implementation(project(":infinitic-avro"))
 
-    testImplementation("org.jeasy:easy-random-core:4.2.+")
-    testImplementation("io.kotest:kotest-runner-junit5-jvm:4.2.+")
-    testImplementation("io.kotest:kotest-property-jvm:4.2.+")
-    testImplementation("io.mockk:mockk:1.10.+")
+    testImplementation("org.jeasy:easy-random-core:${project.extra["easyrandom_version"]}")
+    testImplementation("io.kotest:kotest-runner-junit5-jvm:${project.extra["kotest_version"]}")
+    testImplementation("io.kotest:kotest-property-jvm:${project.extra["kotest_version"]}")
+    testImplementation("io.mockk:mockk:${project.extra["mockk_version"]}")
 }
 
 java {

--- a/infinitic-engine-pulsar/build.gradle.kts
+++ b/infinitic-engine-pulsar/build.gradle.kts
@@ -34,6 +34,7 @@ plugins {
 }
 
 dependencies {
+    implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
     implementation(kotlin("stdlib-jdk8"))
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.9")
     implementation("org.apache.pulsar:pulsar-client:2.6.+")

--- a/infinitic-engine-pulsar/build.gradle.kts
+++ b/infinitic-engine-pulsar/build.gradle.kts
@@ -36,9 +36,9 @@ plugins {
 dependencies {
     implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
     implementation(kotlin("stdlib-jdk8"))
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.9")
-    implementation("org.apache.pulsar:pulsar-client:2.6.+")
-    implementation("org.apache.pulsar:pulsar-functions-api:2.6.+")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${project.extra["kotlinx_coroutines_version"]}")
+    implementation("org.apache.pulsar:pulsar-client:${project.extra["pulsar_version"]}")
+    implementation("org.apache.pulsar:pulsar-functions-api:${project.extra["pulsar_version"]}")
     implementation("org.apache.avro:avro:1.10.+")
     implementation("com.fasterxml.jackson.core:jackson-databind:2.11.+")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.11.+")
@@ -51,10 +51,10 @@ dependencies {
     implementation(project(":infinitic-messaging-pulsar"))
     implementation(project(":infinitic-storage-pulsar"))
 
-    testImplementation("org.jeasy:easy-random-core:4.2.+")
-    testImplementation("io.kotest:kotest-runner-junit5-jvm:4.2.+")
-    testImplementation("io.kotest:kotest-property-jvm:4.2.+")
-    testImplementation("io.mockk:mockk:1.10.+")
+    testImplementation("org.jeasy:easy-random-core:${project.extra["easyrandom_version"]}")
+    testImplementation("io.kotest:kotest-runner-junit5-jvm:${project.extra["kotest_version"]}")
+    testImplementation("io.kotest:kotest-property-jvm:${project.extra["kotest_version"]}")
+    testImplementation("io.mockk:mockk:${project.extra["mockk_version"]}")
 }
 
 application {

--- a/infinitic-engine-pulsar/build.gradle.kts
+++ b/infinitic-engine-pulsar/build.gradle.kts
@@ -39,9 +39,6 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${project.extra["kotlinx_coroutines_version"]}")
     implementation("org.apache.pulsar:pulsar-client:${project.extra["pulsar_version"]}")
     implementation("org.apache.pulsar:pulsar-functions-api:${project.extra["pulsar_version"]}")
-    implementation("org.apache.avro:avro:1.10.+")
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.11.+")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.11.+")
     implementation("org.slf4j:slf4j-api:1.7.+")
     implementation("com.xenomachina:kotlin-argparser:2.0.+")
 

--- a/infinitic-engine/build.gradle.kts
+++ b/infinitic-engine/build.gradle.kts
@@ -27,6 +27,7 @@ plugins {
 }
 
 dependencies {
+    implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
     implementation(kotlin("stdlib-jdk8"))
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.9")
     implementation("org.apache.avro:avro:1.10.+")

--- a/infinitic-engine/build.gradle.kts
+++ b/infinitic-engine/build.gradle.kts
@@ -30,9 +30,6 @@ dependencies {
     implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
     implementation(kotlin("stdlib-jdk8"))
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${project.extra["kotlinx_coroutines_version"]}")
-    implementation("org.apache.avro:avro:1.10.+")
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.11.+")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.11.+")
     implementation("org.slf4j:slf4j-api:1.7.+")
 
     implementation(project(":infinitic-storage-api"))

--- a/infinitic-engine/build.gradle.kts
+++ b/infinitic-engine/build.gradle.kts
@@ -29,7 +29,7 @@ plugins {
 dependencies {
     implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
     implementation(kotlin("stdlib-jdk8"))
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.9")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${project.extra["kotlinx_coroutines_version"]}")
     implementation("org.apache.avro:avro:1.10.+")
     implementation("com.fasterxml.jackson.core:jackson-databind:2.11.+")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.11.+")
@@ -40,10 +40,10 @@ dependencies {
     implementation(project(":infinitic-avro"))
     implementation(project(":infinitic-common"))
 
-    testImplementation("org.jeasy:easy-random-core:4.2.+")
-    testImplementation("io.kotest:kotest-runner-junit5-jvm:4.2.+")
-    testImplementation("io.kotest:kotest-property-jvm:4.2.+")
-    testImplementation("io.mockk:mockk:1.10.+")
+    testImplementation("org.jeasy:easy-random-core:${project.extra["easyrandom_version"]}")
+    testImplementation("io.kotest:kotest-runner-junit5-jvm:${project.extra["kotest_version"]}")
+    testImplementation("io.kotest:kotest-property-jvm:${project.extra["kotest_version"]}")
+    testImplementation("io.mockk:mockk:${project.extra["mockk_version"]}")
 }
 
 java {

--- a/infinitic-messaging-api/build.gradle.kts
+++ b/infinitic-messaging-api/build.gradle.kts
@@ -30,6 +30,7 @@ plugins {
 }
 
 dependencies {
+    implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
     implementation(kotlin("stdlib-jdk8"))
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.9")
 

--- a/infinitic-messaging-api/build.gradle.kts
+++ b/infinitic-messaging-api/build.gradle.kts
@@ -32,15 +32,15 @@ plugins {
 dependencies {
     implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
     implementation(kotlin("stdlib-jdk8"))
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.9")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${project.extra["kotlinx_coroutines_version"]}")
 
     implementation(project(":infinitic-avro"))
     api(project(":infinitic-common"))
 
-    testImplementation("org.jeasy:easy-random-core:4.2.+")
-    testImplementation("io.kotest:kotest-runner-junit5-jvm:4.2.+")
-    testImplementation("io.kotest:kotest-property-jvm:4.2.+")
-    testImplementation("io.mockk:mockk:1.10.+")
+    testImplementation("org.jeasy:easy-random-core:${project.extra["easyrandom_version"]}")
+    testImplementation("io.kotest:kotest-runner-junit5-jvm:${project.extra["kotest_version"]}")
+    testImplementation("io.kotest:kotest-property-jvm:${project.extra["kotest_version"]}")
+    testImplementation("io.mockk:mockk:${project.extra["mockk_version"]}")
 }
 
 java {

--- a/infinitic-messaging-pulsar/build.gradle.kts
+++ b/infinitic-messaging-pulsar/build.gradle.kts
@@ -30,6 +30,7 @@ plugins {
 }
 
 dependencies {
+    implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
     implementation(kotlin("stdlib-jdk8"))
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.9")
     implementation("org.apache.pulsar:pulsar-client:2.6.+")
@@ -42,6 +43,7 @@ dependencies {
     api(project(":infinitic-engine"))
     api(project(":infinitic-worker"))
 
+    testImplementation(kotlin("reflect"))
     testImplementation("org.jeasy:easy-random-core:4.2.+")
     testImplementation("io.kotest:kotest-runner-junit5-jvm:4.2.+")
     testImplementation("io.kotest:kotest-property-jvm:4.2.+")

--- a/infinitic-messaging-pulsar/build.gradle.kts
+++ b/infinitic-messaging-pulsar/build.gradle.kts
@@ -32,9 +32,9 @@ plugins {
 dependencies {
     implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
     implementation(kotlin("stdlib-jdk8"))
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.9")
-    implementation("org.apache.pulsar:pulsar-client:2.6.+")
-    implementation("org.apache.pulsar:pulsar-functions-api:2.6.+")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${project.extra["kotlinx_coroutines_version"]}")
+    implementation("org.apache.pulsar:pulsar-client:${project.extra["pulsar_version"]}")
+    implementation("org.apache.pulsar:pulsar-functions-api:${project.extra["pulsar_version"]}")
     implementation("org.apache.avro:avro:1.10.+")
 
     implementation(project(":infinitic-avro"))
@@ -44,10 +44,10 @@ dependencies {
     api(project(":infinitic-worker"))
 
     testImplementation(kotlin("reflect"))
-    testImplementation("org.jeasy:easy-random-core:4.2.+")
-    testImplementation("io.kotest:kotest-runner-junit5-jvm:4.2.+")
-    testImplementation("io.kotest:kotest-property-jvm:4.2.+")
-    testImplementation("io.mockk:mockk:1.10.+")
+    testImplementation("org.jeasy:easy-random-core:${project.extra["easyrandom_version"]}")
+    testImplementation("io.kotest:kotest-runner-junit5-jvm:${project.extra["kotest_version"]}")
+    testImplementation("io.kotest:kotest-property-jvm:${project.extra["kotest_version"]}")
+    testImplementation("io.mockk:mockk:${project.extra["mockk_version"]}")
 }
 
 java {

--- a/infinitic-messaging-pulsar/build.gradle.kts
+++ b/infinitic-messaging-pulsar/build.gradle.kts
@@ -35,7 +35,6 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${project.extra["kotlinx_coroutines_version"]}")
     implementation("org.apache.pulsar:pulsar-client:${project.extra["pulsar_version"]}")
     implementation("org.apache.pulsar:pulsar-functions-api:${project.extra["pulsar_version"]}")
-    implementation("org.apache.avro:avro:1.10.+")
 
     implementation(project(":infinitic-avro"))
     api(project(":infinitic-messaging-api"))

--- a/infinitic-rest-api/build.gradle
+++ b/infinitic-rest-api/build.gradle
@@ -44,6 +44,7 @@ repositories {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     implementation "io.ktor:ktor-server-netty:$ktor_version"
     implementation "ch.qos.logback:logback-classic:$logback_version"
     implementation "io.ktor:ktor-server-core:$ktor_version"

--- a/infinitic-rest-api/gradle.properties
+++ b/infinitic-rest-api/gradle.properties
@@ -1,7 +1,7 @@
 logback_version=1.2.1
 ktor_version=1.3.2
 kotlin.code.style=official
-kotlin_version=1.3.72
+kotlin_version=1.4.10
 
 prestojdbc_version=333
 koin_version=2.1.5

--- a/infinitic-storage-api/build.gradle.kts
+++ b/infinitic-storage-api/build.gradle.kts
@@ -30,6 +30,7 @@ plugins {
 }
 
 dependencies {
+    implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
     implementation(kotlin("stdlib-jdk8"))
 }
 

--- a/infinitic-storage-pulsar/build.gradle.kts
+++ b/infinitic-storage-pulsar/build.gradle.kts
@@ -32,7 +32,7 @@ plugins {
 dependencies {
     implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
     implementation(kotlin("stdlib-jdk8"))
-    implementation("org.apache.pulsar:pulsar-functions-api:2.6.+")
+    implementation("org.apache.pulsar:pulsar-functions-api:${project.extra["pulsar_version"]}")
 
     api(project(":infinitic-storage-api"))
 }

--- a/infinitic-storage-pulsar/build.gradle.kts
+++ b/infinitic-storage-pulsar/build.gradle.kts
@@ -30,6 +30,7 @@ plugins {
 }
 
 dependencies {
+    implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
     implementation(kotlin("stdlib-jdk8"))
     implementation("org.apache.pulsar:pulsar-functions-api:2.6.+")
 

--- a/infinitic-tests/build.gradle.kts
+++ b/infinitic-tests/build.gradle.kts
@@ -27,6 +27,7 @@ plugins {
 }
 
 dependencies {
+    implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
     implementation(kotlin("stdlib-jdk8"))
     implementation("org.apache.avro:avro:1.10.+")
     implementation("com.fasterxml.jackson.core:jackson-databind:2.11.+")

--- a/infinitic-tests/build.gradle.kts
+++ b/infinitic-tests/build.gradle.kts
@@ -29,9 +29,6 @@ plugins {
 dependencies {
     implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
     implementation(kotlin("stdlib-jdk8"))
-    implementation("org.apache.avro:avro:1.10.+")
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.11.+")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.11.+")
     implementation("org.slf4j:slf4j-api:1.7.+")
 
     testImplementation(project(":infinitic-avro"))

--- a/infinitic-tests/build.gradle.kts
+++ b/infinitic-tests/build.gradle.kts
@@ -42,11 +42,11 @@ dependencies {
     testImplementation(project(":infinitic-client"))
     testImplementation(project(":infinitic-worker"))
 
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.9")
-    testImplementation("org.jeasy:easy-random-core:4.2.+")
-    testImplementation("io.kotest:kotest-runner-junit5-jvm:4.2.+")
-    testImplementation("io.kotest:kotest-property-jvm:4.2.+")
-    testImplementation("io.mockk:mockk:1.10.+")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${project.extra["kotlinx_coroutines_version"]}")
+    testImplementation("org.jeasy:easy-random-core:${project.extra["easyrandom_version"]}")
+    testImplementation("io.kotest:kotest-runner-junit5-jvm:${project.extra["kotest_version"]}")
+    testImplementation("io.kotest:kotest-property-jvm:${project.extra["kotest_version"]}")
+    testImplementation("io.mockk:mockk:${project.extra["mockk_version"]}")
 }
 
 java {

--- a/infinitic-worker-pulsar/build.gradle.kts
+++ b/infinitic-worker-pulsar/build.gradle.kts
@@ -30,6 +30,7 @@ plugins {
 }
 
 dependencies {
+    implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
     implementation(kotlin("stdlib-jdk8"))
     implementation("org.apache.pulsar:pulsar-client:2.6.+")
     implementation("org.apache.pulsar:pulsar-functions-api:2.6.+")

--- a/infinitic-worker-pulsar/build.gradle.kts
+++ b/infinitic-worker-pulsar/build.gradle.kts
@@ -32,13 +32,13 @@ plugins {
 dependencies {
     implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
     implementation(kotlin("stdlib-jdk8"))
-    implementation("org.apache.pulsar:pulsar-client:2.6.+")
-    implementation("org.apache.pulsar:pulsar-functions-api:2.6.+")
+    implementation("org.apache.pulsar:pulsar-client:${project.extra["pulsar_version"]}")
+    implementation("org.apache.pulsar:pulsar-functions-api:${project.extra["pulsar_version"]}")
     implementation("org.apache.avro:avro:1.10.+")
     implementation("com.fasterxml.jackson.core:jackson-databind:2.11.+")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.11.+")
     implementation("org.slf4j:slf4j-api:1.7.+")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.9")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${project.extra["kotlinx_coroutines_version"]}")
 
     implementation(project(":infinitic-avro"))
     implementation(project(":infinitic-common"))
@@ -46,10 +46,10 @@ dependencies {
     implementation(project(":infinitic-worker"))
     implementation(project(":infinitic-messaging-pulsar"))
 
-    testImplementation("org.jeasy:easy-random-core:4.2.+")
-    testImplementation("io.kotest:kotest-runner-junit5-jvm:4.2.+")
-    testImplementation("io.kotest:kotest-property-jvm:4.2.+")
-    testImplementation("io.mockk:mockk:1.10.+")
+    testImplementation("org.jeasy:easy-random-core:${project.extra["easyrandom_version"]}")
+    testImplementation("io.kotest:kotest-runner-junit5-jvm:${project.extra["kotest_version"]}")
+    testImplementation("io.kotest:kotest-property-jvm:${project.extra["kotest_version"]}")
+    testImplementation("io.mockk:mockk:${project.extra["mockk_version"]}")
 }
 
 java {

--- a/infinitic-worker-pulsar/build.gradle.kts
+++ b/infinitic-worker-pulsar/build.gradle.kts
@@ -34,9 +34,6 @@ dependencies {
     implementation(kotlin("stdlib-jdk8"))
     implementation("org.apache.pulsar:pulsar-client:${project.extra["pulsar_version"]}")
     implementation("org.apache.pulsar:pulsar-functions-api:${project.extra["pulsar_version"]}")
-    implementation("org.apache.avro:avro:1.10.+")
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.11.+")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.11.+")
     implementation("org.slf4j:slf4j-api:1.7.+")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${project.extra["kotlinx_coroutines_version"]}")
 

--- a/infinitic-worker/build.gradle.kts
+++ b/infinitic-worker/build.gradle.kts
@@ -30,6 +30,7 @@ plugins {
 }
 
 dependencies {
+    implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
     implementation(kotlin("stdlib-jdk8"))
     implementation("org.apache.avro:avro:1.10.+")
     implementation("com.fasterxml.jackson.core:jackson-databind:2.11.+")

--- a/infinitic-worker/build.gradle.kts
+++ b/infinitic-worker/build.gradle.kts
@@ -36,16 +36,16 @@ dependencies {
     implementation("com.fasterxml.jackson.core:jackson-databind:2.11.+")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.11.+")
     implementation("org.slf4j:slf4j-api:1.7.+")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.9")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${project.extra["kotlinx_coroutines_version"]}")
 
     implementation(project(":infinitic-avro"))
     implementation(project(":infinitic-common"))
     implementation(project(":infinitic-messaging-api"))
 
-    testImplementation("org.jeasy:easy-random-core:4.2.+")
-    testImplementation("io.kotest:kotest-runner-junit5-jvm:4.2.+")
-    testImplementation("io.kotest:kotest-property-jvm:4.2.+")
-    testImplementation("io.mockk:mockk:1.10.+")
+    testImplementation("org.jeasy:easy-random-core:${project.extra["easyrandom_version"]}")
+    testImplementation("io.kotest:kotest-runner-junit5-jvm:${project.extra["kotest_version"]}")
+    testImplementation("io.kotest:kotest-property-jvm:${project.extra["kotest_version"]}")
+    testImplementation("io.mockk:mockk:${project.extra["mockk_version"]}")
 }
 
 java {

--- a/infinitic-worker/build.gradle.kts
+++ b/infinitic-worker/build.gradle.kts
@@ -32,9 +32,7 @@ plugins {
 dependencies {
     implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
     implementation(kotlin("stdlib-jdk8"))
-    implementation("org.apache.avro:avro:1.10.+")
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.11.+")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.11.+")
+    implementation(kotlin("reflect"))
     implementation("org.slf4j:slf4j-api:1.7.+")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${project.extra["kotlinx_coroutines_version"]}")
 


### PR DESCRIPTION
This PR removes the warning about kotlin-reflect having a different version than the kotlin stdlib using kotlin-bom. (see https://stackoverflow.com/questions/59790315/what-does-kotlin-bom-library-do)

I updated the rest api to kotlin 1.4.10 as we overlooked it in the previous PR.

I also took the opportunity to remove many dependencies in various modules that are not necessary (mainly avro and jackson).

Finally, I put the version number of some shared dependencies in the root build file to make future upgrades easier.