### PR TITLE
JSON deserialization shouldn't fail on additional fields

### DIFF
--- a/infinitic-common/src/main/kotlin/io/infinitic/common/serDe/SerializedData.kt
+++ b/infinitic-common/src/main/kotlin/io/infinitic/common/serDe/SerializedData.kt
@@ -51,7 +51,10 @@ data class SerializedData(
         const val META_JAVA_CLASS = "javaClass"
 
         // use a less obvious key than "type" for polymorphic data, to avoid collusion
-        private val jsonKotlin = kotlinx.serialization.json.Json { classDiscriminator = "#klass" }
+        private val jsonKotlin = kotlinx.serialization.json.Json {
+            classDiscriminator = "#klass"
+            ignoreUnknownKeys = true
+        }
 
         /**
          * @return serialized value

--- a/infinitic-common/src/main/kotlin/io/infinitic/common/serDe/json/Json.kt
+++ b/infinitic-common/src/main/kotlin/io/infinitic/common/serDe/json/Json.kt
@@ -27,6 +27,7 @@ package io.infinitic.common.serDe.json
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.JsonSerializer
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.databind.SerializerProvider
@@ -44,6 +45,7 @@ object Json {
         configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
         addModule(JavaTimeModule())
         addModule(KotlinModule.Builder().build())
+        configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
     }
 
     fun stringify(msg: Any?, pretty: Boolean = false): String = when (pretty) {

--- a/infinitic-common/src/main/kotlin/io/infinitic/common/serDe/json/Json.kt
+++ b/infinitic-common/src/main/kotlin/io/infinitic/common/serDe/json/Json.kt
@@ -33,6 +33,7 @@ import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.databind.SerializerProvider
 import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.KotlinFeature
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.fasterxml.jackson.module.kotlin.jsonMapper
 import org.apache.avro.specific.SpecificRecordBase
@@ -44,7 +45,7 @@ object Json {
         addMixIn(Exception::class.java, ExceptionMixIn::class.java)
         configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
         addModule(JavaTimeModule())
-        addModule(KotlinModule.Builder().build())
+        addModule(KotlinModule.Builder().configure(KotlinFeature.NullIsSameAsDefault, true).build())
         configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
     }
 

--- a/infinitic-common/src/test/kotlin/io/infinitic/common/serDe/SerDeJacksonTests.kt
+++ b/infinitic-common/src/test/kotlin/io/infinitic/common/serDe/SerDeJacksonTests.kt
@@ -1,0 +1,191 @@
+/**
+ * "Commons Clause" License Condition v1.0
+ *
+ * The Software is provided to you by the Licensor under the License, as defined
+ * below, subject to the following condition.
+ *
+ * Without limiting other conditions in the License, the grant of rights under the
+ * License will not include, and the License does not grant to you, the right to
+ * Sell the Software.
+ *
+ * For purposes of the foregoing, “Sell” means practicing any or all of the rights
+ * granted to you under the License to provide to third parties, for a fee or
+ * other consideration (including without limitation fees for hosting or
+ * consulting/ support services related to the Software), a product or service
+ * whose value derives, entirely or substantially, from the functionality of the
+ * Software. Any license notice or attribution required by the License must also
+ * include this Commons Clause License Condition notice.
+ *
+ * Software: Infinitic
+ *
+ * License: MIT License (https://opensource.org/licenses/MIT)
+ *
+ * Licensor: infinitic.io
+ */
+
+package io.infinitic.common.serDe
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import io.infinitic.common.fixtures.TestFactory
+import io.infinitic.common.workflows.data.steps.Step
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class SerDeJacksonTests : StringSpec({
+
+    "Null (Obj) should be serializable / deserializable" {
+        val obj1: JObj1? = null
+        val obj2 = SerializedData.from(obj1).deserialize()
+
+        obj2 shouldBe obj1
+    }
+
+    "Primitive (ByteArray) should be serializable / deserializable" {
+        val bytes1: ByteArray = TestFactory.random()
+        val bytes2 = SerializedData.from(bytes1).deserialize() as ByteArray
+
+        bytes1.contentEquals(bytes2) shouldBe true
+    }
+
+    "Primitive (Short) should be serializable / deserializable" {
+        val val1: Short = TestFactory.random()
+        println(SerializedData.from(val1))
+        val val2 = SerializedData.from(val1).deserialize()
+
+        val2 shouldBe val1
+    }
+
+    "Primitive (Int) should be serializable / deserializable" {
+        val val1: Int = TestFactory.random()
+        val val2 = SerializedData.from(val1).deserialize()
+
+        val2 shouldBe val1
+    }
+
+    "Primitive (Long) should be serializable / deserializable" {
+        val val1: Long = TestFactory.random()
+        val val2 = SerializedData.from(val1).deserialize()
+
+        val2 shouldBe val1
+    }
+
+    "Primitive (Float) should be serializable / deserializable" {
+        val val1: Float = TestFactory.random()
+        val val2 = SerializedData.from(val1).deserialize()
+
+        val2 shouldBe val1
+    }
+
+    "Primitive (Double) should be serializable / deserializable" {
+        val val1: Double = TestFactory.random()
+        val val2 = SerializedData.from(val1).deserialize()
+
+        val2 shouldBe val1
+    }
+
+    "Primitive (Boolean) should be serializable / deserializable" {
+        val val1: Boolean = TestFactory.random()
+        val val2 = SerializedData.from(val1).deserialize()
+
+        val2 shouldBe val1
+    }
+
+    "Primitive (Char) should be serializable / deserializable" {
+        val val1: Char = TestFactory.random()
+        val val2 = SerializedData.from(val1).deserialize()
+
+        val2 shouldBe val1
+    }
+
+    "String should be serializable / deserializable" {
+        val val1: String = TestFactory.random()
+        val val2 = SerializedData.from(val1).deserialize()
+
+        val2 shouldBe val1
+    }
+
+    "List Of primitives should be serializable / deserializable" {
+        val val1 = listOf(42F, true, "!@#%")
+        val val2 = SerializedData.from(val1).deserialize()
+
+        val2 shouldBe val1
+    }
+
+    "Simple Object should be serializable / deserializable" {
+        val val1 = JObj1("42", 42, TypeJ.TYPE_1)
+        val val2 = SerializedData.from(val1).deserialize()
+
+        val2 shouldBe val1
+    }
+
+    "Object should be deserializable with additionnal properties" {
+        val val1 = JObj1("42", 42, TypeJ.TYPE_1)
+        val valtmp = JObj2("40", 40)
+        val data = SerializedData.from(valtmp).also {
+            it.bytes = SerializedData.from(val1).bytes
+        }
+        val val2 = data.deserialize() as JObj2
+
+        val2.foo shouldBe val1.foo
+        val2.bar shouldBe val2.bar
+    }
+
+    "Object containing set of sealed should be serializable / deserializable (even with a 'type' property)" {
+        val val1 = JObjs(setOf(JObj1("42", 42, TypeJ.TYPE_1)))
+        val val2 = SerializedData.from(val1).deserialize()
+
+        val2 shouldBe val1
+    }
+
+    "Step.Id should be serializable / deserializable" {
+        val step1 = TestFactory.random<Step.Id>()
+        val step2 = SerializedData.from(step1).deserialize()
+
+        step2 shouldBe step1
+    }
+
+    "Step.Or should be serializable / deserializable" {
+        val step1 = TestFactory.random<Step.Or>()
+        val step2 = SerializedData.from(step1).deserialize()
+
+        step2 shouldBe step1
+    }
+
+    "Step.And should be serializable / deserializable" {
+        val step1 = TestFactory.random<Step.And>()
+        val step2 = SerializedData.from(step1).deserialize()
+
+        step2 shouldBe step1
+    }
+
+    "Comparing SerializedData" {
+        val step = TestFactory.random<Step>()
+        val s1 = SerializedData.from(step)
+        val s2 = SerializedData.from(step)
+
+        s1 shouldBe s2
+    }
+
+//    "List of simple Objects should be serializable / deserializable" {
+//        val val1 = listOf(JObj1("42", 42, TypeJ.TYPE_1), JObj1("24", 24, TypeJ.TYPE_2))
+//        val val2 = SerializedData.from(val1).deserialize()
+//
+//        val1 shouldBe val2
+//    }
+})
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.DEDUCTION
+)
+sealed class JObj
+
+enum class TypeJ {
+    TYPE_1,
+    TYPE_2,
+}
+
+data class JObj1(val foo: String, val bar: Int, val type: TypeJ) : JObj()
+
+data class JObj2(val foo: String, val bar: Int) : JObj()
+
+data class JObjs(val objs: Set<JObj>)

--- a/infinitic-common/src/test/kotlin/io/infinitic/common/serDe/SerDeTests.kt
+++ b/infinitic-common/src/test/kotlin/io/infinitic/common/serDe/SerDeTests.kt
@@ -118,6 +118,18 @@ class SerDeTests : StringSpec({
         val2 shouldBe val1
     }
 
+    "Object should be deserializable with additionnal properties" {
+        val val1 = Obj1("42", 42, Type.TYPE_1)
+        val valtmp = Obj2("40", 40)
+        val data = SerializedData.from(valtmp).also {
+            it.bytes = SerializedData.from(val1).bytes
+        }
+        val val2 = data.deserialize() as Obj2
+
+        val2.foo shouldBe val1.foo
+        val2.bar shouldBe val2.bar
+    }
+
     "Object containing set of sealed should be serializable / deserializable (even with a 'type' property)" {
         val val1 = Objs(setOf(Obj1("42", 42, Type.TYPE_1)))
         val val2 = SerializedData.from(val1).deserialize()
@@ -172,6 +184,9 @@ enum class Type {
 
 @Serializable
 data class Obj1(val foo: String, val bar: Int, val type: Type) : Obj()
+
+@Serializable
+data class Obj2(val foo: String, val bar: Int) : Obj()
 
 @Serializable
 data class Objs(val objs: Set<Obj>)


### PR DESCRIPTION
If additional fields are added to object passed in between client, workflow and task through a common dependency, the additional properties make the deserialization failed if one of the part isn't up to date (missing fields in their definition).
```
Trying to deserialize data into "MetaData" but an error occurred during Kotlin deserialization: kotlinx.serialization.json.internal.JsonDecodingException: Unexpected JSON token at offset 46: Encountered an unknown key 'publishedAt'.
Use 'ignoreUnknownKeys = true' in 'Json {}' builder to ignore unknown keys.
```
To be more tolerant with modification of user object I added the `ignoreUnknownKeys` in kotlinx and `FAIL_ON_UNKNOWN_PROPERTIES` to false in jackson