### PR TITLE
use createdMissedPartition when topic already exist in case partition has been deleted

### DIFF
--- a/infinitic-pulsar/src/main/kotlin/io/infinitic/pulsar/PulsarInfiniticWorker.kt
+++ b/infinitic-pulsar/src/main/kotlin/io/infinitic/pulsar/PulsarInfiniticWorker.kt
@@ -235,7 +235,16 @@ class PulsarInfiniticWorker private constructor(
                     logger.warn { "Not authorized to create topic $topic: ${e.message}" }
                 }
             } else {
-                logger.debug { "Already existing topic $topic" }
+                try {
+                    logger.debug { "Already existing topic $topic" }
+                    createMissedPartitions(topic)
+                } catch (e: PulsarAdminException.ConflictException) {
+                    logger.warn { "Already existing partition $topic: ${e.message}" }
+                } catch (e: PulsarAdminException.NotAllowedException) {
+                    logger.warn { "Not allowed to create topic $topic: ${e.message}" }
+                } catch (e: PulsarAdminException.NotAuthorizedException) {
+                    logger.warn { "Not authorized to create topic $topic: ${e.message}" }
+                }
             }
         }
 


### PR DESCRIPTION
It seems pulsar auto delete topic/partition not used after some time.
Is could be the problem for this issue: https://github.com/infiniticio/infinitic/issues/148