### PR TITLE
Bump Slf4j version to 2.0.3 and kotlin logging

### DIFF
--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -95,12 +95,12 @@ object Libs {
     }
 
     object Slf4j {
-        private const val version = "1.7.36"
+        private const val version = "2.0.3"
         const val simple = "org.slf4j:slf4j-simple:$version"
         const val api = "org.slf4j:slf4j-api:$version"
     }
 
     object Logging {
-        const val api = "io.github.microutils:kotlin-logging:2.1.23"
+        const val api = "io.github.microutils:kotlin-logging:3.0.0"
     }
 }

--- a/infinitic-workflow-task/src/main/kotlin/io/infinitic/workflows/workflowTask/WorkflowDispatcherImpl.kt
+++ b/infinitic-workflow-task/src/main/kotlin/io/infinitic/workflows/workflowTask/WorkflowDispatcherImpl.kt
@@ -419,9 +419,12 @@ internal class WorkflowDispatcherImpl(
         .find { it.commandPosition == methodRunPosition }
 
     private fun throwWorkflowUpdatedException(pastCommand: PastCommand?, newCommand: PastCommand?): Nothing {
-        logger.error { "pastCommand = ${pastCommand?.command}" }
-        logger.error { "newCommand  = ${newCommand?.command}" }
-        logger.error { "workflowChangeCheckMode = ${workflowTaskParameters.workflowOptions.workflowChangeCheckMode}" }
+        logger.error {
+            """Workflow past and new commands are different
+            |pastCommand = ${pastCommand?.command}
+            |newCommand  = ${newCommand?.command}
+            |workflowChangeCheckMode = ${workflowTaskParameters.workflowOptions.workflowChangeCheckMode}""".trimMargin()
+        }
         throw WorkflowUpdatedException(
             workflowTaskParameters.workflowName.name,
             "${workflowTaskParameters.methodRun.methodName}",
@@ -451,8 +454,11 @@ internal class WorkflowDispatcherImpl(
 
         // if it exists, check it has not changed
         if (pastStep != null && !pastStep.isSameThan(newStep)) {
-            logger.error { "pastStep = $pastStep" }
-            logger.error { "newStep = $newStep" }
+            logger.error {
+                """Workflow past and new step are different
+                |pastStep = $pastStep
+                |newStep = $newStep""".trimMargin()
+            }
             throw WorkflowUpdatedException(
                 workflowTaskParameters.workflowName.name,
                 "${workflowTaskParameters.methodRun.methodName}",


### PR DESCRIPTION
bump slf4j and kotlin logging

also remove multiple error log separated in favor of multiline, this is to avoid separation of the logs in ELK