### PR TITLE
Update Avro4k library and improve JSON serialization - Fix#232

### DIFF
--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -84,7 +84,7 @@ object Libs {
   }
 
   object Avro4k {
-    const val core = "com.github.avro-kotlin.avro4k:avro4k-core:1.10.0"
+    const val core = "com.github.avro-kotlin.avro4k:avro4k-core:1.10.1"
   }
 
   object Hoplite {

--- a/infinitic-common/src/main/kotlin/io/infinitic/common/serDe/json/Json.kt
+++ b/infinitic-common/src/main/kotlin/io/infinitic/common/serDe/json/Json.kt
@@ -37,7 +37,7 @@ import org.apache.avro.specific.SpecificRecordBase
 import java.io.IOException
 
 object Json {
-  private val mapper = jsonMapper {
+  var mapper = jsonMapper {
     addMixIn(SpecificRecordBase::class.java, AvroMixIn::class.java)
     addMixIn(Exception::class.java, ExceptionMixIn::class.java)
     addModule(JavaTimeModule())
@@ -46,7 +46,7 @@ object Json {
     configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
     configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
   }
-  
+
   fun stringify(msg: Any?, pretty: Boolean = false): String =
       when (pretty) {
         true -> mapper.writerWithDefaultPrettyPrinter().writeValueAsString(msg)

--- a/infinitic-common/src/test/kotlin/io/infinitic/common/serDe/SerDeJacksonTests.kt
+++ b/infinitic-common/src/test/kotlin/io/infinitic/common/serDe/SerDeJacksonTests.kt
@@ -23,72 +23,92 @@
 package io.infinitic.common.serDe
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo
+import com.fasterxml.jackson.databind.MapperFeature
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.jsonMapper
+import io.infinitic.common.serDe.json.Json
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrowAny
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 
 class SerDeJacksonTests :
-    StringSpec({
-      "Null (Obj) should be serializable / deserializable" {
-        val obj1: JObj1? = null
-        val obj2 = SerializedData.from(obj1).deserialize()
+  StringSpec(
+      {
+        "Null (Obj) should be serializable / deserializable" {
+          val obj1: JObj1? = null
+          val obj2 = SerializedData.from(obj1).deserialize()
 
-        obj2 shouldBe obj1
-      }
+          obj2 shouldBe obj1
+        }
 
-      "Simple Object should be serializable / deserializable" {
-        val val1 = JObj1("42", 42, JType.TYPE_1)
-        val val2 = SerializedData.from(val1).deserialize()
+        "Simple Object should be serializable / deserializable" {
+          val val1 = JObj1("42", 42, JType.TYPE_1)
+          val val2 = SerializedData.from(val1).deserialize()
 
-        val2 shouldBe val1
-      }
+          val2 shouldBe val1
+        }
 
-      "Object should be deserializable with more properties" {
-        val val1 = JObj1("42", 42, JType.TYPE_1)
-        val data =
-            SerializedData.from(val1)
-                .copy(
-                    meta =
-                        mapOf(
-                            SerializedData.META_JAVA_CLASS to
-                                JObj2::class.java.name.toByteArray(charset = Charsets.UTF_8)))
-        val val2 = data.deserialize() as JObj2
+        "Object should be deserializable with more properties" {
+          val val1 = JObj1("42", 42, JType.TYPE_1)
+          val data =
+              SerializedData.from(val1)
+                  .copy(
+                      meta =
+                      mapOf(
+                          SerializedData.META_JAVA_CLASS to
+                              JObj2::class.java.name.toByteArray(charset = Charsets.UTF_8),
+                      ),
+                  )
+          val val2 = data.deserialize() as JObj2
 
-        val2.foo shouldBe val1.foo
-        val2.bar shouldBe val1.bar
-      }
+          val2.foo shouldBe val1.foo
+          val2.bar shouldBe val1.bar
+        }
 
-      "Object should be deserializable with less properties using default value" {
-        val val2 = JObj2("42", 42)
-        val data =
-            SerializedData.from(val2)
-                .copy(
-                    meta =
-                        mapOf(
-                            SerializedData.META_JAVA_CLASS to
-                                JObj1::class.java.name.toByteArray(charset = Charsets.UTF_8)))
-        val val1 = data.deserialize() as JObj1
+        "Object should be deserializable with less properties using default value" {
+          val val2 = JObj2("42", 42)
+          val data =
+              SerializedData.from(val2)
+                  .copy(
+                      meta =
+                      mapOf(
+                          SerializedData.META_JAVA_CLASS to
+                              JObj1::class.java.name.toByteArray(charset = Charsets.UTF_8),
+                      ),
+                  )
+          val val1 = data.deserialize() as JObj1
 
-        val1.foo shouldBe val2.foo
-        val1.bar shouldBe val2.bar
-        val1.type shouldBe JType.TYPE_1
-      }
+          val1.foo shouldBe val2.foo
+          val1.bar shouldBe val2.bar
+          val1.type shouldBe JType.TYPE_1
+        }
 
-      "Object containing set of sealed should be serializable / deserializable (even with a 'type' property)" {
-        val val1 = JObjs(setOf(JObj1("42", 42, JType.TYPE_1)))
-        val val2 = SerializedData.from(val1).deserialize()
+        "Object containing set of sealed should be serializable / deserializable (even with a 'type' property)" {
+          val val1 = JObjs(setOf(JObj1("42", 42, JType.TYPE_1)))
+          val val2 = SerializedData.from(val1).deserialize()
 
-        val2 shouldBe val1
-      }
+          val2 shouldBe val1
+        }
 
-      //    "List of simple Objects should be serializable / deserializable" {
-      //        val val1 = listOf(JObj1("42", 42, TypeJ.TYPE_1), JObj1("24", 24, TypeJ.TYPE_2))
-      //        val val2 = SerializedData.from(val1).deserialize()
-      //
-      //        val1 shouldBe val2
-      //    }
-    })
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION) private sealed class JObj
+        "Can alter Json.mapper" {
+          // this serialization is broken due to "Foo" attribute instead of "foo"
+          val jsonTxt = "{\"Foo\":\"foo\",\"bar\":42,\"type\":\"TYPE_1\"}"
+          shouldThrowAny { Json.parse(jsonTxt, klass = JObj1::class.java) }
+          // we replace the mapper to clear cache and configure ACCEPT_CASE_INSENSITIVE_PROPERTIES
+          Json.mapper = jsonMapper {
+            addModule(KotlinModule.Builder().build())
+            configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true)
+          }
+          shouldNotThrowAny { Json.parse(jsonTxt, klass = JObj1::class.java) }
+        }
+      },
+  )
+
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION)
+private sealed class JObj
 
 private enum class JType {
   TYPE_1,


### PR DESCRIPTION
The Avro4k library version is updated from 1.10.0 to 1.10.1. Jackson objectmapper can now be updated