### PR TITLE
Expand @Ignore annotation targets

### DIFF
--- a/infinitic-common/src/main/kotlin/io/infinitic/annotations/Ignore.kt
+++ b/infinitic-common/src/main/kotlin/io/infinitic/annotations/Ignore.kt
@@ -26,4 +26,5 @@ package io.infinitic.annotations
  * Use this annotation to flag properties that should be ignored when storing the state of a
  * workflow
  */
-@Target(AnnotationTarget.PROPERTY) annotation class Ignore
+@Target(AnnotationTarget.FIELD, AnnotationTarget.PROPERTY)
+annotation class Ignore

--- a/infinitic-common/src/test/java/io/infinitic/annotations/IgnoreTest.java
+++ b/infinitic-common/src/test/java/io/infinitic/annotations/IgnoreTest.java
@@ -1,0 +1,41 @@
+/*
+ * "Commons Clause" License Condition v1.0
+ *
+ * The Software is provided to you by the Licensor under the License, as defined below, subject to
+ * the following condition.
+ *
+ * Without limiting other conditions in the License, the grant of rights under the License will not
+ * include, and the License does not grant to you, the right to Sell the Software.
+ *
+ * For purposes of the foregoing, “Sell” means practicing any or all of the rights granted to you
+ * under the License to provide to third parties, for a fee or other consideration (including
+ * without limitation fees for hosting or consulting/ support services related to the Software), a
+ * product or service whose value derives, entirely or substantially, from the functionality of the
+ * Software. Any license notice or attribution required by the License must also include this
+ * Commons Clause License Condition notice.
+ *
+ * Software: Infinitic
+ *
+ * License: MIT License (https://opensource.org/licenses/MIT)
+ *
+ * Licensor: infinitic.io
+ */
+
+package io.infinitic.annotations;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class IgnoreTest {
+    @Ignore
+    private String ignoredField;
+
+    @Test
+    public void testIgnoreAnnotationPresentOnField() throws NoSuchFieldException {
+        // Get the field from the class by its name
+        var field = this.getClass().getDeclaredField("ignoredField");
+
+        // Assert that the field is annotated with the Ignore annotation
+        Assertions.assertTrue(field.isAnnotationPresent(Ignore.class));
+    }
+}


### PR DESCRIPTION
The @Ignore annotation is now applicable to fields as well asj properties. This modification allows Java users to use this annotation