### PR TITLE
fix: override key() in AddTagToWorkflow/RemoveTagFromWorkflow to avoid hot-key

### DIFF
--- a/infinitic-common/src/main/kotlin/io/infinitic/common/workflows/tags/messages/WorkflowTagEngineMessage.kt
+++ b/infinitic-common/src/main/kotlin/io/infinitic/common/workflows/tags/messages/WorkflowTagEngineMessage.kt
@@ -181,7 +181,9 @@ data class AddTagToWorkflow(
   val workflowId: WorkflowId,
   override val emitterName: EmitterName,
   @AvroDefault(Avro.NULL) override val emittedAt: MillisInstant?
-) : WorkflowTagEngineMessage()
+) : WorkflowTagEngineMessage() {
+  override fun key() = "${workflowTag}:${workflowId}"
+}
 
 /**
  * This message is a command to tell the tag engine that a workflow with the provided tag is not running anymore
@@ -194,7 +196,9 @@ data class RemoveTagFromWorkflow(
   val workflowId: WorkflowId,
   override val emitterName: EmitterName,
   @AvroDefault(Avro.NULL) override val emittedAt: MillisInstant?
-) : WorkflowTagEngineMessage()
+) : WorkflowTagEngineMessage() {
+  override fun key() = "${workflowTag}:${workflowId}"
+}
 
 /**
  * This message is a command to request the tag engine to send back the ids of all workflows with the provided tag

--- a/infinitic-common/src/test/kotlin/io/infinitic/common/workflows/tags/messages/WorkflowTagEnvelopeTests.kt
+++ b/infinitic-common/src/test/kotlin/io/infinitic/common/workflows/tags/messages/WorkflowTagEnvelopeTests.kt
@@ -42,8 +42,15 @@ class WorkflowTagEnvelopeTests :
         WorkflowTagEngineMessage::class.sealedSubclasses.map {
           val msg = randomWorkflowTagMessage(it)
 
-          "WorkflowTagMessage(${msg::class.simpleName}) should have its tag as key" {
-            msg.key() shouldBe msg.workflowTag.toString()
+          "WorkflowTagMessage(${msg::class.simpleName}) should have expected key" {
+            when (msg) {
+              is AddTagToWorkflow ->
+                msg.key() shouldBe "${msg.workflowTag}:${msg.workflowId}"
+              is RemoveTagFromWorkflow ->
+                msg.key() shouldBe "${msg.workflowTag}:${msg.workflowId}"
+              else ->
+                msg.key() shouldBe msg.workflowTag.toString()
+            }
           }
         }
 


### PR DESCRIPTION
## Problem

`AddTagToWorkflow` and `RemoveTagFromWorkflow` inherit the default `key()` which returns `workflowTag.toString()`.

When many workflows share the same tag (e.g. dispatching thousands of workflows with a `customId`), all messages get the same Pulsar key. With `Key_Shared` subscription, this routes every message to a **single consumer**, creating a hot-key bottleneck.

## Fix

Override `key()` in both data classes to return `"${workflowTag}:${workflowId}"`, distributing messages across all consumers while preserving ordering per workflow-tag pair.

## Changes

- `WorkflowTagEngineMessage.kt`: override `key()` in `AddTagToWorkflow` and `RemoveTagFromWorkflow`

## Testing

- Verified compilation with `./gradlew compileKotlin`