### PR TITLE
fix: prevent over-fetch in getWorkflowIdsPage with Redis duplicates

### DIFF
--- a/infinitic-workflow-tag/src/main/kotlin/io/infinitic/workflows/tag/storage/BinaryWorkflowTagStorage.kt
+++ b/infinitic-workflow-tag/src/main/kotlin/io/infinitic/workflows/tag/storage/BinaryWorkflowTagStorage.kt
@@ -65,7 +65,7 @@ class BinaryWorkflowTagStorage(keySetStorage: KeySetStorage) :
     var nextCursor = cursor
 
     do {
-      val page = keySetStorage.getPage(key, limit, nextCursor)
+      val page = keySetStorage.getPage(key, limit - workflowIds.size, nextCursor)
       page.values.forEach { workflowIds.add(WorkflowId(String(it))) }
       nextCursor = page.nextCursor
     } while (workflowIds.size < limit && nextCursor != null)

--- a/infinitic-workflow-tag/src/test/kotlin/io/infinitic/workflows/tag/storage/BinaryWorkflowTagStorageTest.kt
+++ b/infinitic-workflow-tag/src/test/kotlin/io/infinitic/workflows/tag/storage/BinaryWorkflowTagStorageTest.kt
@@ -122,5 +122,60 @@ class BinaryWorkflowTagStorageTest : FunSpec(
         page.workflowIds shouldContainExactly listOf(id1, id2)
         page.nextCursor shouldBe "cursor-2"
       }
+      test("getWorkflowIdsPage should not over-fetch when duplicates cause re-iteration") {
+        // When duplicates reduce the LinkedHashSet below limit, the loop must
+        // request only the deficit (limit - size), not the full limit.
+        // Otherwise the cursor overshoots and IDs are permanently skipped.
+        val workflowName = WorkflowName("test-name")
+        val workflowTag = WorkflowTag("test-tag")
+
+        // 4 unique IDs stored across pages
+        val allIds = (1..4).map { "id-$it".toByteArray() }
+        var requestedLimits = mutableListOf<Int>()
+
+        val keySetStorage = object : KeySetStorage {
+          override suspend fun get(key: String) = emptySet<ByteArray>()
+
+          override suspend fun getPage(key: String, limit: Int, cursor: String?): KeySetPage {
+            requestedLimits.add(limit)
+            val offset = cursor?.toIntOrNull() ?: 0
+            // First call: inject a duplicate to simulate Redis SSCAN behavior
+            val values = if (offset == 0) {
+              listOf(allIds[0], allIds[0]) // duplicate → LinkedHashSet gets 1 unique
+            } else {
+              allIds.drop(offset).take(limit)
+            }
+            val nextOffset = if (offset == 0) 1 else offset + limit
+            val nextCursor = if (nextOffset < allIds.size) nextOffset.toString() else null
+            return KeySetPage(values = values, nextCursor = nextCursor)
+          }
+
+          override suspend fun add(key: String, value: ByteArray) = Unit
+          override suspend fun remove(key: String, value: ByteArray) = Unit
+          override suspend fun get(keys: Set<String>) = emptyMap<String, Set<ByteArray>>()
+          override suspend fun update(
+            add: Map<String, Set<ByteArray>>,
+            remove: Map<String, Set<ByteArray>>,
+          ) = Unit
+          override fun flush() = Unit
+          override fun close() = Unit
+        }
+        val storage = BinaryWorkflowTagStorage(keySetStorage)
+
+        val page = storage.getWorkflowIdsPage(workflowTag, workflowName, limit = 2)
+
+        // First call: limit=2, got 2 items but 1 dup → set size=1 → loop continues
+        // Second call should request limit=1 (the deficit), not limit=2
+        requestedLimits[0] shouldBe 2
+        requestedLimits[1] shouldBe 1
+
+        page.workflowIds.size shouldBe 2
+        page.workflowIds[0] shouldBe WorkflowId("id-1")
+        page.workflowIds[1] shouldBe WorkflowId("id-2")
+
+        // Cursor must be non-null — id-3 and id-4 still remain
+        page.nextCursor shouldBe "2"
+      }
+
     },
 )


### PR DESCRIPTION
## Summary

Fixes #295 — `BinaryWorkflowTagStorage.getWorkflowIdsPage()` can silently skip workflow IDs when Redis SSCAN returns duplicates during hash table rehashing.

## Problem

The accumulation loop in `getWorkflowIdsPage()` always passes the full `limit` to `keySetStorage.getPage()`. When Redis SSCAN returns duplicates, the `LinkedHashSet` deduplicates them, making `workflowIds.size < limit`. The loop re-iterates but requests the full `limit` again instead of the deficit (`limit - workflowIds.size`). This causes the cursor to advance past items that are then discarded by `take(limit)`, permanently skipping workflow IDs.

### Reproduction scenario

- Redis backend, tag with 7,000 workflow IDs, `fanoutPageSize=5000`
- First `getPage(limit=5000)` returns 5,000 items with 10 duplicates → `LinkedHashSet` has 4,990
- Loop continues, calls `getPage(limit=5000)` instead of `getPage(limit=10)`
- Redis returns all 2,000 remaining items, `nextCursor=null`
- `LinkedHashSet` has 6,990 items, `take(5000)` returns 5,000, `nextCursor=null`
- **1,990 workflow IDs are permanently skipped** — the caller stops paginating

## Fix

One-line change: `limit` → `limit - workflowIds.size` in the `getPage()` call.

## What was tested

- Added a unit test that verifies the requested limit on re-iteration equals the deficit
- All existing `BinaryWorkflowTagStorageTest` tests pass

## Note

This bug was identified through AI-assisted code analysis (Kiro) while reviewing the v0.18.3 release for impact on the tag-engine batch feature.