### PR TITLE
fix: inline first page fanout to eliminate extra Pulsar round-trip

### DIFF
--- a/infinitic-workflow-tag/src/main/kotlin/io/infinitic/workflows/tag/WorkflowTagEngine.kt
+++ b/infinitic-workflow-tag/src/main/kotlin/io/infinitic/workflows/tag/WorkflowTagEngine.kt
@@ -147,31 +147,49 @@ class WorkflowTagEngine(
       is RemoveTagFromWorkflow -> removeTagFromWorkflow(storage, message)
       is GetWorkflowIdsByTag -> getWorkflowIds(storage, producer, message)
       is DispatchWorkflowByCustomId -> dispatchByCustomId(storage, producer, message, publishTime)
-      is DispatchMethodByTag -> enqueueInitialFanoutContinuation(producer, message, publishTime)
-      is SendSignalByTag -> enqueueInitialFanoutContinuation(producer, message, publishTime)
-      is CancelWorkflowByTag -> enqueueInitialFanoutContinuation(producer, message, publishTime)
-      is RetryWorkflowTaskByTag -> enqueueInitialFanoutContinuation(producer, message, publishTime)
-      is RetryTasksByTag -> enqueueInitialFanoutContinuation(producer, message, publishTime)
-      is CompleteTimersByTag -> enqueueInitialFanoutContinuation(producer, message, publishTime)
+      is DispatchMethodByTag -> inlineFanout(storage, producer, message, publishTime)
+      is SendSignalByTag -> inlineFanout(storage, producer, message, publishTime)
+      is CancelWorkflowByTag -> inlineFanout(storage, producer, message, publishTime)
+      is RetryWorkflowTaskByTag -> inlineFanout(storage, producer, message, publishTime)
+      is RetryTasksByTag -> inlineFanout(storage, producer, message, publishTime)
+      is CompleteTimersByTag -> inlineFanout(storage, producer, message, publishTime)
       is ContinueWorkflowTagFanout -> continueFanout(storage, producer, message)
     }
   }
 
-  private suspend fun enqueueInitialFanoutContinuation(
+  private suspend fun inlineFanout(
+    storage: WorkflowTagStorage,
     producer: InfiniticProducer,
     message: WorkflowTagFanoutMessage,
     publishTime: MillisInstant,
   ) {
     val normalizedMessage = normalizeFanoutMessage(message, publishTime)
-    val continuation = ContinueWorkflowTagFanout.from(
-        operationId = message.messageId ?: thisShouldNotHappen(),
+
+    val page = storage.getWorkflowIdsPage(
+        tag = normalizedMessage.workflowTag,
+        workflowName = normalizedMessage.workflowName,
         limit = fanoutPageSize,
-        command = normalizedMessage,
-        emitterName = emitterName,
-        emittedAt = normalizedMessage.emittedAt,
     )
 
-    with(producer) { continuation.sendTo(WorkflowTagEngineTopic) }
+    if (page.workflowIds.isEmpty()) {
+      discardTagWithoutIds(normalizedMessage as WorkflowTagEngineMessage)
+      return
+    }
+
+    fanoutPage(producer, normalizedMessage, page.workflowIds)
+
+    // Only use self-messaging for subsequent pages
+    page.nextCursor?.let { nextCursor ->
+      val continuation = ContinueWorkflowTagFanout.from(
+          operationId = message.messageId ?: thisShouldNotHappen(),
+          limit = fanoutPageSize,
+          cursor = nextCursor,
+          command = normalizedMessage,
+          emitterName = emitterName,
+          emittedAt = normalizedMessage.emittedAt,
+      )
+      with(producer) { continuation.sendTo(WorkflowTagEngineTopic) }
+    }
   }
 
   private suspend fun continueFanout(

--- a/infinitic-workflow-tag/src/test/kotlin/io/infinitic/workflows/tag/WorkflowTagEngineTests.kt
+++ b/infinitic-workflow-tag/src/test/kotlin/io/infinitic/workflows/tag/WorkflowTagEngineTests.kt
@@ -73,35 +73,29 @@ import kotlin.random.Random
 
 class WorkflowTagEngineTests : StringSpec(
     {
-      "public ByTag messages should enqueue an internal continuation" {
+      "public ByTag messages should inline the first page fanout" {
         val workflowIds = setOf(WorkflowId(), WorkflowId())
         val message = random<RetryTasksByTag>()
         val harness = getHarness(message.workflowTag, message.workflowName, workflowIds)
 
         harness.engine.process(message, MillisInstant.now())
 
-        coVerify(exactly = 0) { harness.storage.getWorkflowIds(message.workflowTag, message.workflowName) }
-        coVerify(exactly = 0) {
-          harness.storage.getWorkflowIdsPage(message.workflowTag, message.workflowName, any(), any())
+        coVerify(exactly = 1) {
+          harness.storage.getWorkflowIdsPage(message.workflowTag, message.workflowName, 5000, null)
         }
-        harness.tagMessages.single().shouldBeInstanceOf<ContinueWorkflowTagFanout>()
-        harness.workflowCmdMessages.size shouldBe 0
-
-        val continuation = harness.tagMessages.single() as ContinueWorkflowTagFanout
-        continuation.limit shouldBe 5000
-        continuation.command().shouldBeInstanceOf<RetryTasksByTag>()
+        // No continuation produced — all IDs fit in one page
+        harness.tagMessages.size shouldBe 0
+        // Fanout happened inline
+        harness.workflowCmdMessages.filterIsInstance<RetryTasks>().map { it.workflowId }
+            .shouldContainExactlyInAnyOrder(workflowIds.toList())
       }
 
-      "CancelWorkflowByTag continuation should fan out one CancelWorkflow per workflow id" {
+      "CancelWorkflowByTag should fan out one CancelWorkflow per workflow id inline" {
         val workflowIds = listOf(WorkflowId(), WorkflowId())
         val message = random<CancelWorkflowByTag>()
         val harness = getHarness(message.workflowTag, message.workflowName, workflowIds.toSet())
 
         harness.engine.process(message, MillisInstant.now())
-        val continuation = harness.tagMessages.single() as ContinueWorkflowTagFanout
-
-        harness.tagMessages.clear()
-        harness.engine.process(continuation, MillisInstant.now())
 
         coVerify(exactly = 1) {
           harness.storage.getWorkflowIdsPage(message.workflowTag, message.workflowName, 5000, null)
@@ -112,22 +106,19 @@ class WorkflowTagEngineTests : StringSpec(
         harness.tagMessages.size shouldBe 0
       }
 
-      "RetryWorkflowTaskByTag continuation should fan out one RetryWorkflowTask per workflow id" {
+      "RetryWorkflowTaskByTag should fan out one RetryWorkflowTask per workflow id inline" {
         val workflowIds = listOf(WorkflowId(), WorkflowId())
         val message = random<RetryWorkflowTaskByTag>()
         val harness = getHarness(message.workflowTag, message.workflowName, workflowIds.toSet())
 
         harness.engine.process(message, MillisInstant.now())
-        val continuation = harness.tagMessages.single() as ContinueWorkflowTagFanout
-
-        harness.tagMessages.clear()
-        harness.engine.process(continuation, MillisInstant.now())
 
         harness.workflowCmdMessages.filterIsInstance<RetryWorkflowTask>().map { it.workflowId }
             .shouldContainExactlyInAnyOrder(workflowIds)
+        harness.tagMessages.size shouldBe 0
       }
 
-      "SendSignalByTag continuation should request the next page when cursor remains" {
+      "SendSignalByTag should inline first page and enqueue continuation when cursor remains" {
         val workflowId = WorkflowId()
         val message = random<SendSignalByTag>()
         val harness = getHarness(
@@ -142,12 +133,10 @@ class WorkflowTagEngineTests : StringSpec(
         } returns firstPage
 
         harness.engine.process(message, MillisInstant.now())
-        val continuation = harness.tagMessages.single() as ContinueWorkflowTagFanout
 
-        harness.tagMessages.clear()
-        harness.engine.process(continuation, MillisInstant.now())
-
+        // First page fanned out inline
         harness.workflowCmdMessages.single().shouldBeInstanceOf<SendSignal>()
+        // Continuation enqueued for next page
         harness.tagMessages.single().shouldBeInstanceOf<ContinueWorkflowTagFanout>()
         (harness.tagMessages.single() as ContinueWorkflowTagFanout).cursor shouldBe "cursor-2"
       }
@@ -180,18 +169,16 @@ class WorkflowTagEngineTests : StringSpec(
             nextCursor = null,
         )
 
+        // First page is inline
         harness.engine.process(message, MillisInstant.now())
-        val firstContinuation = harness.tagMessages.single() as ContinueWorkflowTagFanout
+        harness.workflowCmdMessages.filterIsInstance<SendSignal>().map { it.workflowId } shouldBe
+            listOf(workflowIds.first())
+        val continuation = harness.tagMessages.single() as ContinueWorkflowTagFanout
+        continuation.cursor shouldBe "cursor-2"
 
+        // Second page via continuation
         harness.tagMessages.clear()
-        harness.engine.process(firstContinuation, MillisInstant.now())
-        harness.workflowCmdMessages.filterIsInstance<SendSignal>().map { it.workflowId }
-            .shouldContainExactlyInAnyOrder(listOf(workflowIds.first()))
-        val secondContinuation = harness.tagMessages.single() as ContinueWorkflowTagFanout
-        secondContinuation.cursor shouldBe "cursor-2"
-
-        harness.tagMessages.clear()
-        harness.engine.process(secondContinuation, MillisInstant.now())
+        harness.engine.process(continuation, MillisInstant.now())
 
         harness.workflowCmdMessages.filterIsInstance<SendSignal>().map { it.workflowId }
             .shouldContainExactlyInAnyOrder(workflowIds)


### PR DESCRIPTION
## Summary

Refs #297 — Eliminates the unconditional `ContinueWorkflowTagFanout` self-message that was causing a performance regression in v0.18.3.

## Problem

In v0.18.3, all tag-based fanout operations (`SendSignalByTag`, `CancelWorkflowByTag`, etc.) unconditionally produce a `ContinueWorkflowTagFanout` message back to the topic before doing any work. This adds an extra Pulsar round-trip for **every** operation, even when the tag has a single workflow ID.

Production metrics showed: 82ms → 7,084ms avg processing time (86x regression), 10,851 in-flight messages backlog.

## Fix

The first page of workflow IDs is now fetched and fanned out **inline** during the initial message processing. `ContinueWorkflowTagFanout` is only produced when there are additional pages (`nextCursor != null`).

**Before:**
```
SendSignalByTag → produce ContinueWorkflowTagFanout → consume → getWorkflowIdsPage → fanout
```

**After:**
```
SendSignalByTag → getWorkflowIdsPage → fanout (→ produce ContinueWorkflowTagFanout only if more pages)
```

For tags with fewer IDs than `fanoutPageSize` (the common case), no `ContinueWorkflowTagFanout` is produced at all. Pagination for large tags still works via continuations for subsequent pages.

## What was tested

All existing tests updated and passing (10/10). Tests verify:
- Small tags: inline fanout, no continuation produced
- Large tags (fanoutPageSize=1): first page inline, continuation for subsequent pages
- Full pagination: all pages fanned out correctly
- Batch processing equivalence: batch and one-by-one produce identical results