### PR TITLE
fix: preserve batch fast-path when non-add/remove messages are present

### DIFF
--- a/infinitic-workflow-tag/src/main/kotlin/io/infinitic/workflows/tag/WorkflowTagEngine.kt
+++ b/infinitic-workflow-tag/src/main/kotlin/io/infinitic/workflows/tag/WorkflowTagEngine.kt
@@ -81,19 +81,23 @@ class WorkflowTagEngine(
   ) {
     if (messages.isEmpty()) return
 
-    if (messages.all { (message, _) -> message is AddTagToWorkflow || message is RemoveTagFromWorkflow }) {
-      batchProcessAddRemoveOnly(messages)
-      return
+    val (addRemove, others) = messages.partition { (message, _) ->
+      message is AddTagToWorkflow || message is RemoveTagFromWorkflow
     }
 
-    val messagesMap: Map<Pair<WorkflowTag, WorkflowName>, List<Pair<WorkflowTagEngineMessage, MillisInstant>>> =
-        messages.groupBy { it.first.workflowTag to it.first.workflowName }
+    // Process add/remove through the optimized bulk path
+    if (addRemove.isNotEmpty()) {
+      batchProcessAddRemoveOnly(addRemove)
+    }
 
-    coroutineScope {
-      messagesMap
-          .map { (tagAndName, messages) ->
-            launch { batchProcessByTag(storage, producer, messages) }
-          }
+    // Process remaining messages (fanout, customId, getIds, continuations) per tag
+    if (others.isNotEmpty()) {
+      val messagesMap = others.groupBy { it.first.workflowTag to it.first.workflowName }
+      coroutineScope {
+        messagesMap.map { (_, groupedMessages) ->
+          launch { batchProcessByTag(storage, producer, groupedMessages) }
+        }
+      }
     }
   }
 

--- a/infinitic-workflow-tag/src/test/kotlin/io/infinitic/workflows/tag/WorkflowTagEngineTests.kt
+++ b/infinitic-workflow-tag/src/test/kotlin/io/infinitic/workflows/tag/WorkflowTagEngineTests.kt
@@ -217,6 +217,41 @@ class WorkflowTagEngineTests : StringSpec(
         (harness.clientMessages.single() as WorkflowIdsByTag).workflowIds shouldBe workflowIds
       }
 
+      "batch with mixed message types should use bulk path for add/remove" {
+        val workflowIds = setOf(WorkflowId(), WorkflowId())
+        val tag = WorkflowTag("test-tag")
+        val name = WorkflowName("test-name")
+        val harness = getHarness(tag, name, workflowIds)
+
+        val addMsg = random<AddTagToWorkflow>(
+            mapOf("workflowTag" to tag, "workflowName" to name),
+        )
+        val removeMsg = random<RemoveTagFromWorkflow>(
+            mapOf("workflowTag" to tag, "workflowName" to name),
+        )
+        val fanoutMsg = random<SendSignalByTag>(
+            mapOf("workflowTag" to tag, "workflowName" to name),
+        )
+
+        val now = MillisInstant.now()
+        harness.engine.batchProcess(
+            listOf(addMsg to now, removeMsg to now, fanoutMsg to now),
+        )
+
+        // Bulk path used for add/remove (getWorkflowIds with Set<Pair> + updateWorkflowIds)
+        coVerify(exactly = 1) {
+          harness.storage.getWorkflowIds(match<Set<Pair<WorkflowTag, WorkflowName>>> { it.isNotEmpty() })
+        }
+        coVerify(exactly = 1) { harness.storage.updateWorkflowIds(any(), any()) }
+
+        // Individual addWorkflowId/removeWorkflowId NOT called (bulk path handles them)
+        coVerify(exactly = 0) { harness.storage.addWorkflowId(any(), any(), any()) }
+        coVerify(exactly = 0) { harness.storage.removeWorkflowId(any(), any(), any()) }
+
+        // The fanout message was also processed (produced a continuation)
+        harness.tagMessages.single().shouldBeInstanceOf<ContinueWorkflowTagFanout>()
+      }
+
       "batch processing should do the same than one by one processing" {
         val n = 3
         val tags = List(n) { RandomString.make(10) }


### PR DESCRIPTION
## Summary

Refs #297 — Ensures `AddTagToWorkflow`/`RemoveTagFromWorkflow` messages always use the optimized bulk storage path, even when other message types are in the same batch.

## Problem

`batchProcess()` has a fast-path (`batchProcessAddRemoveOnly`) that does a single bulk Redis read + single bulk Redis write (2 storage calls regardless of batch size). However, this fast-path only activates when **all** messages in the batch are add/remove.

When any other message type is present (e.g., `ContinueWorkflowTagFanout`, `DispatchWorkflowByCustomId`), the entire batch falls into the sequential fallback path where each message hits storage individually — O(N) calls.

Production metrics showed `AddTagToWorkflow` latency went from sub-ms to 6.5s because these messages were stuck in mixed batches.

## Fix

Partition the batch: add/remove messages always go through the bulk path, other messages are processed separately per tag.

```kotlin
val (addRemove, others) = messages.partition { (message, _) ->
    message is AddTagToWorkflow || message is RemoveTagFromWorkflow
}
if (addRemove.isNotEmpty()) batchProcessAddRemoveOnly(addRemove)
if (others.isNotEmpty()) { /* process per tag */ }
```

## What was tested

All 10 existing tests pass, including the batch equivalence test that verifies batch and one-by-one processing produce identical results.